### PR TITLE
feat: Prepare project for npm publishing

### DIFF
--- a/example/main.ts
+++ b/example/main.ts
@@ -1,5 +1,6 @@
 declare const NGL: any;
-import { TrajectoryProxy } from '../src/TrajectoryProxy';
+// import { TrajectoryProxy } from '../src/TrajectoryProxy';
+import { TrajectoryProxy } from 'ngl-data-proxy';
 import { MdsrvDataSource as CustomMdsrvDataSource } from './MdsrvDataSource';
 
 // --- Configuration ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "ngl-data-proxy",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ngl-data-proxy",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/node": "^24.3.0",
+        "ngl-data-proxy": "^0.1.0",
         "typescript": "^5.9.2",
         "vite": "^7.1.3"
       }
@@ -845,6 +846,12 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/ngl-data-proxy": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ngl-data-proxy/-/ngl-data-proxy-0.1.0.tgz",
+      "integrity": "sha512-ZrNakThPWqhbXISNrtXqxK4UL9yfZWiMm3d/6z/GkOejRxtj44apYCw9qF1UohE8zF5X+uEfN/z+nbs8bS8dNQ==",
+      "dev": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ngl-data-proxy",
-  "private": true,
-  "version": "0.0.0",
+  "private": false,
+  "version": "0.1.0",
   "type": "module",
   "main": "./dist/ngl-data-proxy.umd.cjs",
   "module": "./dist/ngl-data-proxy.js",
@@ -22,6 +22,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
+    "ngl-data-proxy": "^0.1.0",
     "typescript": "^5.9.2",
     "vite": "^7.1.3"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "noFallthroughCasesInSwitch": true,
     "allowJs": true
   },
-  "include": ["src", "example"]
+  "include": ["src"]
 }


### PR DESCRIPTION
This commit includes the necessary configurations to publish the project as an npm package:
- Set "private" to false and updated version in package.json.
- Configured tsconfig.json to only include library source files for compilation, resolving build errors.
- Updated example/main.ts to import TrajectoryProxy from the published npm package, demonstrating usage.